### PR TITLE
Makes describeProcess lang optional

### DIFF
--- a/service/src/main/java/org/orbisgis/orbiswps/service/operations/WPS_2_0_OperationsImpl.java
+++ b/service/src/main/java/org/orbisgis/orbiswps/service/operations/WPS_2_0_OperationsImpl.java
@@ -297,21 +297,23 @@ public class WPS_2_0_OperationsImpl implements WPS_2_0_Operations {
 
         ExceptionReport exceptionReport = new ExceptionReport();
 
-        boolean isLang = Arrays.asList(wpsProp.GLOBAL_PROPERTIES.SUPPORTED_LANGUAGES).contains(describeProcess.getLang());
-        if(!isLang) {
-            for (String suppLang : wpsProp.GLOBAL_PROPERTIES.SUPPORTED_LANGUAGES){
-                if(suppLang.substring(0, 2).equalsIgnoreCase(describeProcess.getLang().substring(0, 2))){
-                    isLang = true;
+        if(describeProcess.isSetLang()) {
+            boolean isLang = Arrays.asList(wpsProp.GLOBAL_PROPERTIES.SUPPORTED_LANGUAGES).contains(describeProcess.getLang());
+            if (!isLang) {
+                for (String suppLang : wpsProp.GLOBAL_PROPERTIES.SUPPORTED_LANGUAGES) {
+                    if (suppLang.substring(0, 2).equalsIgnoreCase(describeProcess.getLang().substring(0, 2))) {
+                        isLang = true;
+                    }
                 }
             }
-        }
 
-        if(!isLang){
-            ExceptionType exceptionType = new ExceptionType();
-            exceptionType.setExceptionCode("InvalidParameterValue");
-            exceptionType.setLocator("Lang");
-            exceptionReport.getException().add(exceptionType);
-            return exceptionReport;
+            if (!isLang) {
+                ExceptionType exceptionType = new ExceptionType();
+                exceptionType.setExceptionCode("InvalidParameterValue");
+                exceptionType.setLocator("Lang");
+                exceptionReport.getException().add(exceptionType);
+                return exceptionReport;
+            }
         }
 
         if(describeProcess.getIdentifier().isEmpty()){
@@ -346,9 +348,14 @@ public class WPS_2_0_OperationsImpl implements WPS_2_0_Operations {
                         listTransmission.add(DataTransmissionModeType.VALUE);
                         po.getOutputTransmission().clear();
                         po.getOutputTransmission().addAll(listTransmission);
-                        List<String> languages = new ArrayList<>();
-                        languages.add(describeProcess.getLang());
-                        po.setProcess(ProcessTranslator.getTranslatedProcess(pi, languages));
+                        if(describeProcess.isSetLang()) {
+                            List<String> languages = new ArrayList<>();
+                            languages.add(describeProcess.getLang());
+                            po.setProcess(ProcessTranslator.getTranslatedProcess(pi, languages));
+                        }
+                        else{
+                            po.setProcess(pi.getProcessDescriptionType());
+                        }
                     }
                 }
             }

--- a/testsuite/src/test/java/org/orbisgis/orbiswps/testsuite/DescribeProcessTest.java
+++ b/testsuite/src/test/java/org/orbisgis/orbiswps/testsuite/DescribeProcessTest.java
@@ -142,7 +142,6 @@ public class DescribeProcessTest {
     @Test
     public void testEmptyDescribeProcess(){
         DescribeProcess describeProcess = new DescribeProcess();
-        describeProcess.setLang("en");
 
         Object result = sendRequest(describeProcess, marshaller, service, unmarshaller);
 
@@ -174,6 +173,28 @@ public class DescribeProcessTest {
     }
 
     @Test
+    public void testDescribeProcessResultNoLang() throws Exception {
+        DescribeProcess describeProcess = new DescribeProcess();
+        describeProcess.getIdentifier().addAll(codeTypeList);
+
+        Object result = sendRequest(describeProcess, marshaller, service, unmarshaller);
+
+
+        //Get the WPSCapabilitiesType object
+
+        if(result instanceof ExceptionReport){
+            throw getException((ExceptionReport)result);
+        }
+        else if (!(result instanceof ProcessOfferings)) {
+            fail("The JAXBElement value should be a WPSCapabilitiesType");
+        }
+        ProcessOfferings processOfferings = (ProcessOfferings) result;
+
+        testProcessOfferings(processOfferings, null);
+
+    }
+
+    @Test
     public void testDescribeProcessResult() throws Exception {
         DescribeProcess describeProcess = new DescribeProcess();
         describeProcess.setLang("fr-fr");
@@ -192,6 +213,11 @@ public class DescribeProcessTest {
         }
         ProcessOfferings processOfferings = (ProcessOfferings) result;
 
+        testProcessOfferings(processOfferings, "fr-fr");
+
+    }
+
+    private void testProcessOfferings(ProcessOfferings processOfferings, String lang){
         assertTrue("The property 'processOffering' should be set", processOfferings.isSetProcessOffering());
         for(ProcessOffering processOffering : processOfferings.getProcessOffering()){
             assertTrue("The property 'jobControlOption' should be set",
@@ -235,17 +261,23 @@ public class DescribeProcessTest {
 
             assertTrue("The property 'title' should be set", process.isSetTitle());
             assertEquals("There should be 1 title", 1, process.getTitle().size());
-            assertEquals("The language should be fr-fr", "fr-fr", process.getTitle().get(0).getLang());
+            if(lang != null) {
+                assertEquals("The language should be " + lang, lang, process.getTitle().get(0).getLang());
+            }
 
             if(process.isSetAbstract()){
                 assertEquals("There should be 1 abstract", 1, process.getAbstract().size());
-                assertEquals("The language should be fr-fr", "fr-fr", process.getAbstract().get(0).getLang());
+                if(lang != null) {
+                    assertEquals("The language should be " + lang, lang, process.getAbstract().get(0).getLang());
+                }
             }
 
             if(process.isSetKeywords()){
                 for(KeywordsType keyword : process.getKeywords()) {
                     assertEquals("There should be 1 keyword", 1, keyword.getKeyword().size());
-                    assertEquals("The language should be fr-fr", "fr-fr", keyword.getKeyword().get(0).getLang());
+                    if(lang != null) {
+                        assertEquals("The language should be " + lang, lang, keyword.getKeyword().get(0).getLang());
+                    }
                 }
             }
 
@@ -257,17 +289,23 @@ public class DescribeProcessTest {
                 for(InputDescriptionType input : process.getInput()){
                     assertTrue("The property 'title' of the input should be set", input.isSetTitle());
                     assertEquals("There should be 1 title of the input", 1, input.getTitle().size());
-                    assertEquals("The language of the input should be fr-fr", "fr-fr", input.getTitle().get(0).getLang());
+                    if(lang != null) {
+                        assertEquals("The language of the input should be " + lang, lang, input.getTitle().get(0).getLang());
+                    }
 
                     if(input.isSetAbstract()){
                         assertEquals("There should be 1 abstract of the input", 1, input.getAbstract().size());
-                        assertEquals("The language of the input should be fr-fr", "fr-fr", input.getAbstract().get(0).getLang());
+                        if(lang != null) {
+                            assertEquals("The language of the input should be " + lang, lang, input.getAbstract().get(0).getLang());
+                        }
                     }
 
                     if(input.isSetKeywords()){
                         for(KeywordsType keyword : input.getKeywords()) {
                             assertEquals("There should be 1 keyword of the input", 1, keyword.getKeyword().size());
-                            assertEquals("The language of the input should be fr-fr", "fr-fr", keyword.getKeyword().get(0).getLang());
+                            if(lang != null) {
+                                assertEquals("The language of the input should be " + lang, lang, keyword.getKeyword().get(0).getLang());
+                            }
                         }
                     }
 
@@ -295,17 +333,23 @@ public class DescribeProcessTest {
 
                 assertTrue("The property 'title' of the input should be set", output.isSetTitle());
                 assertEquals("There should be 1 title of the input", 1, output.getTitle().size());
-                assertEquals("The language of the input should be fr-fr", "fr-fr", output.getTitle().get(0).getLang());
+                if(lang != null) {
+                    assertEquals("The language of the input should be " + lang, lang, output.getTitle().get(0).getLang());
+                }
 
                 if(output.isSetAbstract()){
                     assertEquals("There should be 1 abstract of the input", 1, output.getAbstract().size());
-                    assertEquals("The language of the input should be fr-fr", "fr-fr", output.getAbstract().get(0).getLang());
+                    if(lang != null) {
+                        assertEquals("The language of the input should be " + lang, lang, output.getAbstract().get(0).getLang());
+                    }
                 }
 
                 if(output.isSetKeywords()){
                     for(KeywordsType keyword : output.getKeywords()) {
                         assertEquals("There should be 1 keyword of the input", 1, keyword.getKeyword().size());
-                        assertEquals("The language of the input should be fr-fr", "fr-fr", keyword.getKeyword().get(0).getLang());
+                        if(lang != null) {
+                            assertEquals("The language of the input should be " + lang, lang, keyword.getKeyword().get(0).getLang());
+                        }
                     }
                 }
 
@@ -316,7 +360,6 @@ public class DescribeProcessTest {
                 testDataDescriptionType(output.getDataDescription().getValue());
             }
         }
-
     }
 
     private void testDataDescriptionType(DataDescriptionType dataDescriptionType){


### PR DESCRIPTION
Makes the describeProcess property 'lang' optional as written in the WPS standard. Linked to the issue #87 