### PR TITLE
Fix on issue #89: Progression bug when >1 subprocess in ProgressMonitor 

### DIFF
--- a/service/src/main/java/org/orbisgis/orbiswps/service/process/ProgressMonitor.java
+++ b/service/src/main/java/org/orbisgis/orbiswps/service/process/ProgressMonitor.java
@@ -67,7 +67,7 @@ public class ProgressMonitor implements ProgressVisitor {
     /** True if the process has been cancelled, false otherwise. */
     private boolean isCancelled;
     /** Count of step to do. */
-    private int stepCount;
+    private int stepCount = 1;
     /** Count of step done. */
     private int stepDone = 0;
 
@@ -123,7 +123,7 @@ public class ProgressMonitor implements ProgressVisitor {
 
     @Override
     public void endOfProgress() {
-        progressTo(1);
+        progressTo(stepCount);
     }
 
     @Override

--- a/service/src/test/java/org/orbisgis/orbiswps/service/process/ProgressMonitorTest.java
+++ b/service/src/test/java/org/orbisgis/orbiswps/service/process/ProgressMonitorTest.java
@@ -1,0 +1,42 @@
+package org.orbisgis.orbiswps.service.process;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * This test class perform tests on the ProgressMonitor class
+ *
+ * @author Petter Teigen
+ */
+public class ProgressMonitorTest {
+    @Test
+    public void testendOfProgressSetsProgressTo1WithOneSubprocesses(){
+        ProgressMonitor sometask = new ProgressMonitor("Sometask");
+        sometask.endOfProgress();
+        Assert.assertEquals("Expecting progress to be 1d with just one sub process", 1d, sometask.getProgression(), 0);
+    }
+
+    @Test
+    public void testendOfProgressSetsProgressTo1WithSeveralSubprocesses(){
+        ProgressMonitor sometask = new ProgressMonitor("Sometask");
+        sometask.subProcess(10);
+        sometask.endOfProgress();
+        Assert.assertEquals("Expecting progress to be 1d with several sub processes", 1d, sometask.getProgression(), 0);
+    }
+
+    @Test
+    public void testSeveralSubprocessesWillUpdateProgressWithEveryStep(){
+        final int numSubProcesses = 20;
+        ProgressMonitor sometask = new ProgressMonitor("Sometask");
+        sometask.subProcess(numSubProcesses);
+
+        for (int i = 0; i < numSubProcesses; i++) {
+            Assert.assertEquals(i * 1d / numSubProcesses, sometask.getProgression(), 0);
+            sometask.endStep();
+        }
+        Assert.assertEquals("Expecting progress to be 1d even before endOfProgress is called", 1d, sometask.getProgression(), 0);
+
+        sometask.endOfProgress();
+        Assert.assertEquals("Expecting progress to be 1d with several sub ended and endOfProgress() called", 1d, sometask.getProgression(), 0);
+    }
+}


### PR DESCRIPTION
Fixes a bug in the ProgressMonitor class where progression is reset to 1/<stepCount> when stepCount > 1 and endOfProgress() is called. endOfProgress() is called from the ProcessWorker.

As a result of this the WPS-getStatus request reports a progress of for example 5% (when 20 steps) when the process is actually done.

This pull request fixes this bug and adds a test class with some tests on the ProgressMonitor class 