### PR TITLE
Makes WpsServerImpl support parallel running processes + adds exception reports

### DIFF
--- a/service-api/src/main/java/org/orbisgis/orbiswps/serviceapi/operations/WPS_2_0_Operations.java
+++ b/service-api/src/main/java/org/orbisgis/orbiswps/serviceapi/operations/WPS_2_0_Operations.java
@@ -105,7 +105,7 @@ public interface WPS_2_0_Operations {
      *                  processing job, of which the status shall be returned.
      * @return StatusInfo document.
      */
-    StatusInfo getStatus(GetStatus getStatus);
+    Object getStatus(GetStatus getStatus);
 
     /**
      * WPS GetResult operation request. This operation is used to query the results of asynchrously
@@ -117,7 +117,7 @@ public interface WPS_2_0_Operations {
      *                  processing job, of which the result shall be returned.
      * @return Result document.
      */
-    Result getResult(GetResult getResult);
+    Object getResult(GetResult getResult);
 
     /**
      * The dismiss operation allow a client to communicate that he is no longer interested in the results of a job.

--- a/service/src/main/java/org/orbisgis/orbiswps/service/operations/WPS_2_0_OperationsImpl.java
+++ b/service/src/main/java/org/orbisgis/orbiswps/service/operations/WPS_2_0_OperationsImpl.java
@@ -405,6 +405,16 @@ public class WPS_2_0_OperationsImpl implements WPS_2_0_Operations {
         statusInfo.setJobID(jobId.toString());
         //Get the Process
         ProcessIdentifier processIdentifier = processManager.getProcessIdentifier(execute.getIdentifier());
+
+        if (processIdentifier == null){
+            ExceptionReport exceptionReport = new ExceptionReport();
+            ExceptionType exceptionType = new ExceptionType();
+            exceptionType.setExceptionCode("NoSuchProcess");
+            exceptionType.setLocator(execute.getIdentifier().getValue());
+            exceptionReport.getException().add(exceptionType);
+            return exceptionReport;
+        }
+
         //Generate the processInstance
         Job job = new Job(processIdentifier.getProcessDescriptionType(), jobId, dataMap,
                 wpsProp.CUSTOM_PROPERTIES.MAX_PROCESS_POLLING_DELAY,
@@ -422,10 +432,20 @@ public class WPS_2_0_OperationsImpl implements WPS_2_0_Operations {
     }
 
     @Override
-    public StatusInfo getStatus(GetStatus getStatus) {
+    public Object getStatus(GetStatus getStatus) {
         //Get the job concerned by the getStatus request
         UUID jobId = UUID.fromString(getStatus.getJobID());
         Job job = jobMap.get(jobId);
+
+        if (job == null){
+            ExceptionReport exceptionReport = new ExceptionReport();
+            ExceptionType exceptionType = new ExceptionType();
+            exceptionType.setExceptionCode("NoSuchJob");
+            exceptionType.setLocator(getStatus.getJobID());
+            exceptionReport.getException().add(exceptionType);
+            return exceptionReport;
+        }
+
         //Generate the StatusInfo to return
         StatusInfo statusInfo = new StatusInfo();
         statusInfo.setJobID(jobId.toString());
@@ -447,7 +467,7 @@ public class WPS_2_0_OperationsImpl implements WPS_2_0_Operations {
     }
 
     @Override
-    public Result getResult(GetResult getResult) {
+    public Object getResult(GetResult getResult) {
         Result result = new Result();
         //generate the XMLGregorianCalendar Object to put in the Result Object
         long destructionDelay = wpsProp.CUSTOM_PROPERTIES.getDestroyDelayInMillis();
@@ -455,6 +475,16 @@ public class WPS_2_0_OperationsImpl implements WPS_2_0_Operations {
         //Get the concerned Job
         UUID jobId = UUID.fromString(getResult.getJobID());
         Job job = jobMap.get(jobId);
+
+        if (job == null){
+            ExceptionReport exceptionReport = new ExceptionReport();
+            ExceptionType exceptionType = new ExceptionType();
+            exceptionType.setExceptionCode("NoSuchJob");
+            exceptionType.setLocator(getResult.getJobID());
+            exceptionReport.getException().add(exceptionType);
+            return exceptionReport;
+        }
+
         result.setJobID(jobId.toString());
         //Get the list of outputs to transmit
         List<DataOutputType> listOutput = new ArrayList<>();


### PR DESCRIPTION
Hey guys. 

This PR changes the behavior of the WpsServerImpl as it did not support parallel running processes. When passing an ExecutorService to WpsServerImpl that supports more than one thread one would expect the processes to run in parallel. Although they didn't because of workerFIFO and processRunning.

If one process at the time is what you want you should pass a "correct" implementation of ExecutorService

PS: I was concidering to make a property that could turn the old feature (with workerFIFO) on and off. But in the end I thought this was the better solution. I hope you agree :)

--
Petter 