### PR TITLE
Optional language in 1.0.0 and propertyfile-cleanup

### DIFF
--- a/service/src/main/java/org/orbisgis/orbiswps/service/operations/WPS_1_0_0_OperationsImpl.java
+++ b/service/src/main/java/org/orbisgis/orbiswps/service/operations/WPS_1_0_0_OperationsImpl.java
@@ -269,17 +269,19 @@ public class WPS_1_0_0_OperationsImpl implements WPS_1_0_0_Operations {
         List<CodeType> codeTypeList = describeProcess.getIdentifier();
         ProcessDescriptions processDescriptions = new ProcessDescriptions();
 
-        if(language.equals(wpsProp.GLOBAL_PROPERTIES.DEFAULT_LANGUAGE)){
-            processDescriptions.setLang(language);
-        }
-        else {
-            for(String lang : wpsProp.GLOBAL_PROPERTIES.SUPPORTED_LANGUAGES) {
-                if (language.equals(lang)) {
-                    processDescriptions.setLang(language);
+        if(describeProcess.isSetLanguage()) {
+            if (language.equals(wpsProp.GLOBAL_PROPERTIES.DEFAULT_LANGUAGE)) {
+                processDescriptions.setLang(language);
+            } else {
+                for (String lang : wpsProp.GLOBAL_PROPERTIES.SUPPORTED_LANGUAGES) {
+                    if (language.equals(lang)) {
+                        processDescriptions.setLang(language);
 
+                    }
                 }
             }
         }
+
         if(!processDescriptions.isSetLang()){
             processDescriptions.setLang(wpsProp.GLOBAL_PROPERTIES.DEFAULT_LANGUAGE);
             language = wpsProp.GLOBAL_PROPERTIES.DEFAULT_LANGUAGE;

--- a/service/src/main/java/org/orbisgis/orbiswps/service/operations/WpsServerProperties_1_0_0.java
+++ b/service/src/main/java/org/orbisgis/orbiswps/service/operations/WpsServerProperties_1_0_0.java
@@ -82,9 +82,15 @@ public class WpsServerProperties_1_0_0 {
         Properties wpsProperties = null;
         if(propertyFileLocation != null) {
             //Load the property file
-            File propertiesFile = new File(propertyFileLocation + File.separator + SERVER_PROPERTIES);
+            File propertiesFile = new File(propertyFileLocation);
+
+            if (propertiesFile.isDirectory()){
+                propertiesFile = new File(propertyFileLocation + File.separator + SERVER_PROPERTIES);
+            }
+
             if (propertiesFile.exists()) {
                 try {
+                    wpsProperties = new Properties();
                     wpsProperties.load(new FileInputStream(propertiesFile));
                 } catch (IOException e) {
                     LOGGER.warn(I18N.tr("Unable to restore the wps properties."));

--- a/service/src/main/java/org/orbisgis/orbiswps/service/operations/WpsServerProperties_2_0.java
+++ b/service/src/main/java/org/orbisgis/orbiswps/service/operations/WpsServerProperties_2_0.java
@@ -86,6 +86,11 @@ public class WpsServerProperties_2_0 {
         if(propertyFileLocation != null) {
             //Load the property file
             File propertiesFile = new File(propertyFileLocation);
+
+            if (propertiesFile.isDirectory()){
+                propertiesFile = new File(propertyFileLocation + File.separator + SERVER_PROPERTIES);
+            }
+
             if (propertiesFile.exists()) {
                 try {
                     wpsProperties = new Properties();

--- a/service/src/test/java/org/orbisgis/orbiswps/service/operations/TestWPS_1_0_0_OperationsImpl.java
+++ b/service/src/test/java/org/orbisgis/orbiswps/service/operations/TestWPS_1_0_0_OperationsImpl.java
@@ -301,6 +301,21 @@ public class TestWPS_1_0_0_OperationsImpl {
     }
 
     /**
+     * Tests the DescribeProcessOperation without language
+     */
+    @Test
+    public void testDescribeProcessWithoutLanguageShouldNotFail(){
+        DescribeProcess describeProcess = new DescribeProcess();
+        CodeType codeType = new CodeType();
+        codeType.setValue("orbisgis:test:jdbctable");
+        describeProcess.getIdentifier().add(codeType);
+        ProcessDescriptions processDescriptions = wps100Operations.describeProcess(describeProcess);
+
+        Assert.assertNotNull("The wps ProcessDescriptions should not be null", processDescriptions);
+    }
+
+
+    /**
      * Tests the DescribeProcessOperation
      */
     @Test


### PR DESCRIPTION
Makes language optional in WPS 1.0.0 describeprocess (per standard)

Was not able to use the same propertyfile across 1.0.0 and 2.0 versions - fixed. Can now pass a directory or a file.

I wrote the code, it's mine, and I'm contributing to OrbisGIS for distribution licensed under the GPL 3.0.
