### PR TITLE
Execute test and literal outputs

### DIFF
--- a/service/src/main/java/org/orbisgis/orbiswps/service/operations/Converter.java
+++ b/service/src/main/java/org/orbisgis/orbiswps/service/operations/Converter.java
@@ -500,8 +500,12 @@ public class Converter {
                         (org.orbisgis.orbiswps.service.model.BoundingBoxData)outputDescriptionType.getDataDescription().getValue();
                 descriptionType.setBoundingBoxOutput(convertComplexDataTypeToSupportedCrssType(bBox));
             }
-            else if(dataDescriptionType instanceof ComplexDataType){
-                ComplexDataType complexData = (ComplexDataType) outputDescriptionType.getDataDescription().getValue();
+            else if(dataDescriptionType instanceof ComplexDataType && !(dataDescriptionType instanceof JDBCTable)){
+                ComplexDataType complexData = (ComplexDataType) dataDescriptionType;
+                descriptionType.setLiteralOutput(convertComplexDataTypeToLiteralData(complexData));
+            }
+            else {
+                ComplexDataType complexData = (ComplexDataType) dataDescriptionType;
                 descriptionType.setComplexOutput(convertComplexDataTypeToSupportedComplexDataInputType(complexData, maxMb));
             }
             descriptionType.setIdentifier(convertCodeType2to1(outputDescriptionType.getIdentifier()));

--- a/service/src/main/java/org/orbisgis/orbiswps/service/operations/WPS_1_0_0_OperationsImpl.java
+++ b/service/src/main/java/org/orbisgis/orbiswps/service/operations/WPS_1_0_0_OperationsImpl.java
@@ -460,7 +460,7 @@ public class WPS_1_0_0_OperationsImpl implements WPS_1_0_0_Operations {
                     if(!map.isEmpty()) {
                         dataMap.put(id, map.entrySet().iterator().next().getValue());
                     }
-                } else {
+                } else if (input.isSetData() && input.getData().isSetLiteralData())  {
                     dataMap.put(id, input.getData().getLiteralData().getValue());
                 }
             }
@@ -774,6 +774,14 @@ public class WPS_1_0_0_OperationsImpl implements WPS_1_0_0_Operations {
                     exceptionReport.getException().add(exceptionType);
                     return exceptionReport;
                 }
+                if(!input.isSetData()){
+                    ExceptionType exceptionType = new ExceptionType();
+                    exceptionType.setExceptionCode("InvalidParameterValue");
+                    exceptionType.setLocator("DataInputs");
+                    exceptionType.getExceptionText().add("Input without dataType");
+                    exceptionReport.getException().add(exceptionType);
+                    return exceptionReport;
+                }
                 boolean isInput = false;
                 boolean isInputFormat = false;
                 for(net.opengis.wps._2_0.InputDescriptionType inputType :
@@ -919,7 +927,7 @@ public class WPS_1_0_0_OperationsImpl implements WPS_1_0_0_Operations {
             exceptionReport.getException().add(exceptionType);
             return exceptionReport;
         }
-        if(execute.getResponseForm().isSetResponseDocument()) {
+        if(execute.isSetResponseForm() && execute.getResponseForm().isSetResponseDocument()) {
             if (execute.getResponseForm().getResponseDocument().isStoreExecuteResponse()) {
                 if (!wpsProp.GLOBAL_PROPERTIES.STORE_SUPPORTED) {
                     ExceptionType exceptionType = new ExceptionType();

--- a/service/src/main/java/org/orbisgis/orbiswps/service/process/ProcessManager.java
+++ b/service/src/main/java/org/orbisgis/orbiswps/service/process/ProcessManager.java
@@ -44,10 +44,9 @@ import net.opengis.ows._2.CodeType;
 import net.opengis.ows._2.MetadataType;
 import net.opengis.wps._2_0.*;
 import org.orbisgis.orbiswps.groovyapi.attributes.DescriptionTypeAttribute;
+import org.orbisgis.orbiswps.service.model.*;
 import org.orbisgis.orbiswps.service.model.Enumeration;
-import org.orbisgis.orbiswps.service.model.JDBCColumn;
-import org.orbisgis.orbiswps.service.model.JDBCValue;
-import org.orbisgis.orbiswps.service.model.RawData;
+import org.orbisgis.orbiswps.service.model.BoundingBoxData;
 import org.orbisgis.orbiswps.service.parser.ParserController;
 import org.orbisgis.orbiswps.service.utils.CancelClosure;
 import org.orbisgis.orbiswps.service.utils.WpsSql;
@@ -440,7 +439,7 @@ public class ProcessManager {
                             data = data.toString().split("\\t");
                         }
                     }
-                    if(dataDescriptionType instanceof LiteralDataType) {
+                    else if(dataDescriptionType instanceof LiteralDataType) {
                         if (Number.class.isAssignableFrom(field.getType()) && data != null) {
                             try {
                                 Method valueOf = field.getType().getMethod("valueOf", String.class);

--- a/service/src/main/java/org/orbisgis/orbiswps/service/utils/Job.java
+++ b/service/src/main/java/org/orbisgis/orbiswps/service/utils/Job.java
@@ -136,6 +136,14 @@ public class Job implements ProcessExecutionListener, PropertyChangeListener {
     }
 
     /**
+     * Returns the logMap.
+     * @return The logMap.
+     */
+    public Map<String, LogType> getLogMap(){
+        return logMap;
+    }
+
+    /**
      * Returns the process.
      * @return The process.
      */

--- a/service/src/test/java/org/orbisgis/orbiswps/service/operations/TestWPS_1_0_0_DescribeProcess.java
+++ b/service/src/test/java/org/orbisgis/orbiswps/service/operations/TestWPS_1_0_0_DescribeProcess.java
@@ -632,52 +632,7 @@ public class TestWPS_1_0_0_DescribeProcess {
                 fail("Unknown output");
             }
 
-            if("Enumeration".equals(type) || "Geometry".equals(type) || "JDBCColumn".equals(type) ||
-                    "JDBCValue".equals(type) || "Password".equals(type) || "RawData".equals(type)){
-                assertFalse("The 'orbisgis:test:full' 'dataOutputs' 'output' 'literalOutput' should not be set",
-                        output.isSetLiteralOutput());
-                assertFalse("The 'orbisgis:test:full' 'dataOutputs' 'output' 'boundingBox' should not be set",
-                        output.isSetBoundingBoxOutput());
-                assertTrue("The 'orbisgis:test:full' 'dataOutputs' 'output' 'complexOutput' should be set",
-                        output.isSetComplexOutput());
-
-                assertTrue("The 'orbisgis:test:full' 'dataOutputs' 'output' 'complexOutput' 'default' should be set",
-                        output.getComplexOutput().isSetDefault());
-                assertTrue("The 'orbisgis:test:full' 'dataOutputs' 'output' 'complexOutput' 'default' 'format' should be set",
-                        output.getComplexOutput().getDefault().isSetFormat());
-                assertTrue("The 'orbisgis:test:full' 'dataOutputs' 'output' 'complexOutput' 'default' 'format' 'mimeType' should be set",
-                        output.getComplexOutput().getDefault().getFormat().isSetMimeType());
-                assertEquals("The 'orbisgis:test:full' 'dataOutputs' 'output' 'complexOutput' 'default' 'format' 'mimeType' should be set to 'text/plain'",
-                        "text/plain", output.getComplexOutput().getDefault().getFormat().getMimeType());
-                assertTrue("The 'orbisgis:test:full' 'dataOutputs' 'output' 'complexOutput' 'default' 'format' 'schema' should be set",
-                        output.getComplexOutput().getDefault().getFormat().isSetSchema());
-                assertTrue("The 'orbisgis:test:full' 'dataOutputs' 'output' 'complexOutput' 'default' 'format' 'schema' should be empty",
-                        output.getComplexOutput().getDefault().getFormat().getSchema().isEmpty());
-                assertTrue("The 'orbisgis:test:full' 'dataOutputs' 'output' 'complexOutput' 'default' 'format' 'encoding' should be set",
-                        output.getComplexOutput().getDefault().getFormat().isSetEncoding());
-                assertEquals("The 'orbisgis:test:full' 'dataOutputs' 'output' 'complexOutput' 'default' 'format' 'encoding' should be set to 'simple'",
-                        "simple", output.getComplexOutput().getDefault().getFormat().getEncoding());
-
-                assertTrue("The 'orbisgis:test:full' 'dataOutputs' 'output' 'complexOutput' 'supported' should be set",
-                        output.getComplexOutput().isSetSupported());
-                assertTrue("The 'orbisgis:test:full' 'dataOutputs' 'output' 'complexOutput' 'supported' 'format' should be set",
-                        output.getComplexOutput().getSupported().isSetFormat());
-                assertEquals("The 'orbisgis:test:full' 'dataOutputs' 'output' 'complexOutput' 'supported' should contains one value",
-                        1, output.getComplexOutput().getSupported().getFormat().size());
-                assertTrue("The 'orbisgis:test:full' 'dataOutputs' 'output' 'complexOutput' 'supported' 'mimeType' should be set",
-                        output.getComplexOutput().getSupported().getFormat().get(0).isSetMimeType());
-                assertEquals("The 'orbisgis:test:full' 'dataOutputs' 'output' 'complexOutput' 'supported' 'mimeType' should be set to 'text/plain'",
-                        "text/plain", output.getComplexOutput().getSupported().getFormat().get(0).getMimeType());
-                assertTrue("The 'orbisgis:test:full' 'dataOutputs' 'output' 'complexOutput' 'supported' 'schema' should be set",
-                        output.getComplexOutput().getSupported().getFormat().get(0).isSetSchema());
-                assertTrue("The 'orbisgis:test:full' 'dataOutputs' 'output' 'complexOutput' 'supported' 'schema' should be empty",
-                        output.getComplexOutput().getSupported().getFormat().get(0).getSchema().isEmpty());
-                assertTrue("The 'orbisgis:test:full' 'dataOutputs' 'output' 'complexOutput' 'supported' 'encoding' should be set",
-                        output.getComplexOutput().getSupported().getFormat().get(0).isSetEncoding());
-                assertEquals("The 'orbisgis:test:full' 'dataOutputs' 'output' 'complexOutput' 'supported' 'encoding' should be set to 'simple'",
-                        "simple", output.getComplexOutput().getSupported().getFormat().get(0).getEncoding());
-            }
-            else if("JDBCTable".equals(type)){
+            if("JDBCTable".equals(type)){
                 assertFalse("The 'orbisgis:test:full' 'dataOutputs' 'output' 'literalOutput' should not be set",
                         output.isSetLiteralOutput());
                 assertFalse("The 'orbisgis:test:full' 'dataOutputs' 'output' 'boundingBox' should not be set",
@@ -770,7 +725,9 @@ public class TestWPS_1_0_0_DescribeProcess {
                 assertEquals("The 'orbisgis:test:full' 'dataOutputs' 'output' 'literalOutput' 'dataType' 'reference' should be set to 'https://www.w3.org/2001/XMLSchema#double'",
                         "https://www.w3.org/2001/XMLSchema#double", output.getLiteralOutput().getDataType().getReference());
             }
-            else if("LiteralDataString".equals(type)){
+            else if("Enumeration".equals(type) || "Geometry".equals(type) || "JDBCColumn".equals(type) ||
+                    "JDBCValue".equals(type) || "Password".equals(type) || "RawData".equals(type) ||
+                    "LiteralDataString".equals(type)){
                 assertTrue("The 'orbisgis:test:full' 'dataOutputs' 'output' 'literalOutput' should be set",
                         output.isSetLiteralOutput());
                 assertFalse("The 'orbisgis:test:full' 'dataOutputs' 'output' 'boundingBox' should not be set",

--- a/service/src/test/java/org/orbisgis/orbiswps/service/operations/TestWPS_1_0_0_Execute.java
+++ b/service/src/test/java/org/orbisgis/orbiswps/service/operations/TestWPS_1_0_0_Execute.java
@@ -15,8 +15,6 @@ import java.io.File;
 import java.math.BigInteger;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -65,6 +63,438 @@ public class TestWPS_1_0_0_Execute {
         WpsServerProperties_1_0_0 fullWpsProps = new WpsServerProperties_1_0_0(
                 TestWPS_1_0_0_Execute.class.getResource("fullWpsService100.json").getFile());
         fullWps100Operations =  new WPS_1_0_0_OperationsImpl(wpsServer, fullWpsProps, processManager);
+    }
+
+    /**
+     * Test the response to an Execute request with all the input/output defined with a minimal ResponseDocument to
+     * ensure all the data types are wel supported
+     */
+    @Test
+    public void testFullProcessResponseDocumentExecute(){
+        //Execute with only one request output
+        Execute execute = new Execute();
+        CodeType codeType = new CodeType();
+        codeType.setValue("orbisgis:test:full");
+        execute.setIdentifier(codeType);
+
+        //Sets the inputs
+        DataInputsType dataInputsType = new DataInputsType();
+        execute.setDataInputs(dataInputsType);
+
+        InputType inputType = new InputType();
+        CodeType inCodeType = new CodeType();
+        inCodeType.setValue("orbisgis:test:full:input:enumeration");
+        inputType.setIdentifier(inCodeType);
+        DataType dataType  = new DataType();
+        inputType.setData(dataType);
+        LiteralDataType literalDataType = new LiteralDataType();
+        dataType.setLiteralData(literalDataType);
+        literalDataType.setValue("value1");
+        dataInputsType.getInput().add(inputType);
+
+        inputType = new InputType();
+        inCodeType = new CodeType();
+        inCodeType.setValue("orbisgis:test:full:input:geometry");
+        inputType.setIdentifier(inCodeType);
+        dataType  = new DataType();
+        inputType.setData(dataType);
+        literalDataType = new LiteralDataType();
+        dataType.setLiteralData(literalDataType);
+        literalDataType.setValue("geometry");
+        dataInputsType.getInput().add(inputType);
+
+        inputType = new InputType();
+        inCodeType = new CodeType();
+        inCodeType.setValue("orbisgis:test:full:input:jdbctable");
+        inputType.setIdentifier(inCodeType);
+        dataType  = new DataType();
+        inputType.setData(dataType);
+        ComplexDataType complexDataType = new ComplexDataType();
+        dataType.setComplexData(complexDataType);
+        complexDataType.getOtherAttributes().put(new QName("string"), "jdbctable");
+        dataInputsType.getInput().add(inputType);
+
+        inputType = new InputType();
+        inCodeType = new CodeType();
+        inCodeType.setValue("orbisgis:test:full:input:jdbccolumn");
+        inputType.setIdentifier(inCodeType);
+        dataType  = new DataType();
+        inputType.setData(dataType);
+        literalDataType = new LiteralDataType();
+        dataType.setLiteralData(literalDataType);
+        literalDataType.setValue("jdbccolumn");
+        dataInputsType.getInput().add(inputType);
+
+        inputType = new InputType();
+        inCodeType = new CodeType();
+        inCodeType.setValue("orbisgis:test:full:input:jdbcvalue");
+        inputType.setIdentifier(inCodeType);
+        dataType  = new DataType();
+        inputType.setData(dataType);
+        literalDataType = new LiteralDataType();
+        dataType.setLiteralData(literalDataType);
+        literalDataType.setValue("jdbcvalue");
+        dataInputsType.getInput().add(inputType);
+
+        inputType = new InputType();
+        inCodeType = new CodeType();
+        inCodeType.setValue("orbisgis:test:full:input:rawdata");
+        inputType.setIdentifier(inCodeType);
+        dataType  = new DataType();
+        inputType.setData(dataType);
+        literalDataType = new LiteralDataType();
+        dataType.setLiteralData(literalDataType);
+        literalDataType.setValue("rawdata");
+        dataInputsType.getInput().add(inputType);
+
+        inputType = new InputType();
+        inCodeType = new CodeType();
+        inCodeType.setValue("orbisgis:test:full:input:password");
+        inputType.setIdentifier(inCodeType);
+        dataType  = new DataType();
+        inputType.setData(dataType);
+        literalDataType = new LiteralDataType();
+        dataType.setLiteralData(literalDataType);
+        literalDataType.setValue("password");
+        dataInputsType.getInput().add(inputType);
+
+        inputType = new InputType();
+        inCodeType = new CodeType();
+        inCodeType.setValue("orbisgis:test:full:input:literaldatadouble");
+        inputType.setIdentifier(inCodeType);
+        dataType  = new DataType();
+        inputType.setData(dataType);
+        literalDataType = new LiteralDataType();
+        dataType.setLiteralData(literalDataType);
+        literalDataType.setValue("10.0");
+        dataInputsType.getInput().add(inputType);
+
+        inputType = new InputType();
+        inCodeType = new CodeType();
+        inCodeType.setValue("orbisgis:test:full:input:literaldatastring");
+        inputType.setIdentifier(inCodeType);
+        dataType  = new DataType();
+        inputType.setData(dataType);
+        literalDataType = new LiteralDataType();
+        dataType.setLiteralData(literalDataType);
+        literalDataType.setValue("LiteralDataString");
+        dataInputsType.getInput().add(inputType);
+
+        inputType = new InputType();
+        inCodeType = new CodeType();
+        inCodeType.setValue("orbisgis:test:full:input:boundingboxdata");
+        inputType.setIdentifier(inCodeType);
+        dataType  = new DataType();
+        inputType.setData(dataType);
+        BoundingBoxType boundingBoxType = new BoundingBoxType();
+        dataType.setBoundingBoxData(boundingBoxType);
+        boundingBoxType.setCrs("EPSG:4326");
+        boundingBoxType.setDimensions(new BigInteger("2"));
+        boundingBoxType.getUpperCorner().add(1.0);
+        boundingBoxType.getUpperCorner().add(1.1);
+        boundingBoxType.getLowerCorner().add(0.0);
+        boundingBoxType.getLowerCorner().add(0.1);
+        dataInputsType.getInput().add(inputType);
+
+        //Sets the outputs
+        ResponseFormType responseFormType = new ResponseFormType();
+        ResponseDocumentType responseDocumentType = new ResponseDocumentType();
+        responseFormType.setResponseDocument(responseDocumentType);
+        execute.setResponseForm(responseFormType);
+
+        CodeType outCodeType = new CodeType();
+        outCodeType.setValue("orbisgis:test:full:output:enumeration");
+        DocumentOutputDefinitionType documentOutputDefinitionType = new DocumentOutputDefinitionType();
+        documentOutputDefinitionType.setIdentifier(outCodeType);
+        responseDocumentType.getOutput().add(documentOutputDefinitionType);
+
+        outCodeType = new CodeType();
+        outCodeType.setValue("orbisgis:test:full:output:geometry");
+        documentOutputDefinitionType = new DocumentOutputDefinitionType();
+        documentOutputDefinitionType.setIdentifier(outCodeType);
+        responseDocumentType.getOutput().add(documentOutputDefinitionType);
+
+        outCodeType = new CodeType();
+        outCodeType.setValue("orbisgis:test:full:output:jdbctable");
+        documentOutputDefinitionType = new DocumentOutputDefinitionType();
+        documentOutputDefinitionType.setIdentifier(outCodeType);
+        responseDocumentType.getOutput().add(documentOutputDefinitionType);
+
+        outCodeType = new CodeType();
+        outCodeType.setValue("orbisgis:test:full:output:jdbccolumn");
+        documentOutputDefinitionType = new DocumentOutputDefinitionType();
+        documentOutputDefinitionType.setIdentifier(outCodeType);
+        responseDocumentType.getOutput().add(documentOutputDefinitionType);
+
+        outCodeType = new CodeType();
+        outCodeType.setValue("orbisgis:test:full:output:jdbcvalue");
+        documentOutputDefinitionType = new DocumentOutputDefinitionType();
+        documentOutputDefinitionType.setIdentifier(outCodeType);
+        responseDocumentType.getOutput().add(documentOutputDefinitionType);
+
+        outCodeType = new CodeType();
+        outCodeType.setValue("orbisgis:test:full:output:rawdata");
+        documentOutputDefinitionType = new DocumentOutputDefinitionType();
+        documentOutputDefinitionType.setIdentifier(outCodeType);
+        responseDocumentType.getOutput().add(documentOutputDefinitionType);
+
+        outCodeType = new CodeType();
+        outCodeType.setValue("orbisgis:test:full:output:password");
+        documentOutputDefinitionType = new DocumentOutputDefinitionType();
+        documentOutputDefinitionType.setIdentifier(outCodeType);
+        responseDocumentType.getOutput().add(documentOutputDefinitionType);
+
+        outCodeType = new CodeType();
+        outCodeType.setValue("orbisgis:test:full:output:literaldatadouble");
+        documentOutputDefinitionType = new DocumentOutputDefinitionType();
+        documentOutputDefinitionType.setIdentifier(outCodeType);
+        responseDocumentType.getOutput().add(documentOutputDefinitionType);
+
+        outCodeType = new CodeType();
+        outCodeType.setValue("orbisgis:test:full:output:literaldatastring");
+        documentOutputDefinitionType = new DocumentOutputDefinitionType();
+        documentOutputDefinitionType.setIdentifier(outCodeType);
+        responseDocumentType.getOutput().add(documentOutputDefinitionType);
+
+        outCodeType = new CodeType();
+        outCodeType.setValue("orbisgis:test:full:output:boundingboxdata");
+        documentOutputDefinitionType = new DocumentOutputDefinitionType();
+        documentOutputDefinitionType.setIdentifier(outCodeType);
+        responseDocumentType.getOutput().add(documentOutputDefinitionType);
+
+        Object o = fullWps100Operations.execute(execute);
+        assertTrue("The result of the Execute operation should be an ExecuteResponse", o instanceof ExecuteResponse);
+        ExecuteResponse executeResponse = (ExecuteResponse)o;
+
+        assertTrue("The 'lang' property of ExecuteResponse should be set", executeResponse.isSetLang());
+        assertEquals("The 'lang' property of ExecuteResponse should be set to 'en'", "en", executeResponse.getLang());
+
+        assertFalse("The 'statusLocation' property of ExecuteResponse should be set",
+                executeResponse.isSetStatusLocation());
+
+        assertTrue("The 'serviceInstance' property of ExecuteResponse should be set",
+                executeResponse.isSetServiceInstance());
+        assertEquals("The 'serviceInstance' property of ExecuteResponse should be set to 'getcapabilitiesurl1'",
+                "getcapabilitiesurl1", executeResponse.getServiceInstance());
+
+        assertTrue("The 'process' property of ExecuteResponse should be set",
+                executeResponse.isSetProcess());
+        assertTrue("The 'process' 'identifier' property of ExecuteResponse should be set",
+                executeResponse.getProcess().isSetIdentifier());
+        assertTrue("The 'process' 'identifier' 'value' property of ExecuteResponse should be set",
+                executeResponse.getProcess().getIdentifier().isSetValue());
+        assertEquals("The 'process' 'identifier' 'value' property of ExecuteResponse should be set to 'orbisgis:test:full'",
+                "orbisgis:test:full", executeResponse.getProcess().getIdentifier().getValue());
+        assertTrue("The 'process' 'title' property of ExecuteResponse should be set",
+                executeResponse.getProcess().isSetTitle());
+        assertTrue("The 'process' 'title' 'lang' property of ExecuteResponse should be set",
+                executeResponse.getProcess().getTitle().isSetLang());
+        assertEquals("The 'process' 'title' 'lang' property of ExecuteResponse should be set to 'en'", "en",
+                executeResponse.getProcess().getTitle().getLang());
+        assertTrue("The 'process' 'title' 'value' property of ExecuteResponse should be set",
+                executeResponse.getProcess().getTitle().isSetValue());
+        assertEquals("The 'process' 'title' 'value' property of ExecuteResponse should be set to 'full test script'",
+                "full test script", executeResponse.getProcess().getTitle().getValue());
+
+        assertTrue("The 'status' 'creationTime' property of ExecuteResponse should be set",
+                executeResponse.getStatus().isSetCreationTime());
+        assertTrue("The 'status' property of ExecuteResponse should be 'ProcessSucceeded'",
+                executeResponse.getStatus().isSetProcessSucceeded());
+        assertFalse("The 'status' property of ExecuteResponse should not be 'ProcessFailed'",
+                executeResponse.getStatus().isSetProcessFailed());
+        assertFalse("The 'status' property of ExecuteResponse should not be 'ProcessAccepted'",
+                executeResponse.getStatus().isSetProcessAccepted());
+        assertFalse("The 'status' property of ExecuteResponse should not be 'ProcessPaused'",
+                executeResponse.getStatus().isSetProcessPaused());
+        assertFalse("The 'status' property of ExecuteResponse should not be 'ProcessStarted'",
+                executeResponse.getStatus().isSetProcessStarted());
+
+        assertTrue("The 'processOutputs' property of ExecuteResponse should be set",
+                executeResponse.isSetProcessOutputs());
+        assertEquals("The 'processOutputs' property of ExecuteResponse should contains ten value",
+                10, executeResponse.getProcessOutputs().getOutput().size());
+        for(OutputDataType outputDataType : executeResponse.getProcessOutputs().getOutput()){
+            assertTrue("The 'identifier' property of OutputDataType should be set", outputDataType.isSetIdentifier());
+            assertTrue("The 'identifier' 'value' property of OutputDataType should be set",
+                    outputDataType.getIdentifier().isSetValue());
+            assertTrue("Unknown output '"+outputDataType.getIdentifier().getValue()+"'",
+                    outputDataType.getIdentifier().getValue().startsWith("orbisgis:test:full:output:"));
+            String type = outputDataType.getIdentifier().getValue().substring("orbisgis:test:full:output:".length());
+            assertEquals("The 'identifier' property of OutputDataType should be set to 'orbisgis:test:full:output:"+type+"'",
+                    "orbisgis:test:full:output:"+type, outputDataType.getIdentifier().getValue());
+
+            if(type.startsWith("jdbc")){
+                type = type.substring(0, 5).toUpperCase() + type.substring(5);
+            }
+            else if(type.equals("literaldatadouble")){
+                type = "LiteralDataDouble";
+            }
+            else if(type.equals("rawdata")){
+                type = "RawData";
+            }
+            else if(type.equals("literaldatastring")){
+                type = "LiteralDataString";
+            }
+            else if(type.equals("boundingboxdata")){
+                type = "BoundingBoxData";
+            }
+            else {
+                type = type.substring(0, 1).toUpperCase() + type.substring(1);
+            }
+
+            assertTrue("The 'title' property of OutputDataType should be set",
+                    outputDataType.isSetTitle());
+            assertTrue("The 'title' 'lang' property of OutputDataType should be set",
+                    outputDataType.getTitle().isSetLang());
+            assertEquals("The 'title' 'lang' property of OutputDataType should be set to 'en'", "en",
+                    outputDataType.getTitle().getLang());
+            assertTrue("The 'title' 'value' property of OutputDataType should be set",
+                    outputDataType.getTitle().isSetValue());
+            assertEquals("The 'title' 'value' property of OutputDataType should be set to 'Output "+type+"'",
+                    "Output "+type, outputDataType.getTitle().getValue());
+
+            assertTrue("The 'abstract' property of OutputDataType should be set",
+                    outputDataType.isSetAbstract());
+            assertTrue("The 'abstract' 'lang' property of OutputDataType should be set",
+                    outputDataType.getAbstract().isSetLang());
+            assertEquals("The 'abstract' 'lang' property of OutputDataType should be set to 'en'", "en",
+                    outputDataType.getAbstract().getLang());
+            assertTrue("The 'abstract' 'value' property of OutputDataType should be set",
+                    outputDataType.getAbstract().isSetValue());
+            assertEquals("The 'abstract' 'value' property of OutputDataType should be set to 'A "+type+" output.'",
+                    "A "+type+" output.", outputDataType.getAbstract().getValue());
+
+            assertFalse("The 'reference' property of OutputDataType should not be set",
+                    outputDataType.isSetReference());
+            assertTrue("The 'data' property of OutputDataType should be set",
+                    outputDataType.isSetData());
+
+            switch(type){
+                case "JDBCTable" :
+                    assertFalse("The 'data' 'boundingBoxData' property of OutputDataType should not be set",
+                            outputDataType.getData().isSetBoundingBoxData());
+                    assertFalse("The 'data' 'literalData' property of OutputDataType should not be set",
+                            outputDataType.getData().isSetLiteralData());
+                    assertTrue("The 'data' 'complexData' property of OutputDataType should be set",
+                            outputDataType.getData().isSetComplexData());
+
+                    assertTrue("The 'data' 'complexData' 'mimeType' property of OutputDataType should be set",
+                            outputDataType.getData().getComplexData().isSetMimeType());
+                    assertEquals("The 'data' 'complexData' 'mimeType' property of OutputDataType should be set to 'text/xml'",
+                            "text/xml", outputDataType.getData().getComplexData().getMimeType());
+
+                    assertTrue("The 'data' 'complexData' 'content' property of OutputDataType should be set",
+                            outputDataType.getData().getComplexData().isSetContent());
+                    assertEquals("The 'data' 'complexData' 'content' property of OutputDataType should contains one value",
+                            1, outputDataType.getData().getComplexData().getContent().size());
+                    assertTrue("The 'data' 'complexData' 'content' property of OutputDataType should contains 'jdbctable'",
+                            outputDataType.getData().getComplexData().getContent().contains("jdbctable"));
+                    break;
+                case "Enumeration" :
+                    assertFalse("The 'data' 'boundingBoxData' property of OutputDataType should not be set",
+                            outputDataType.getData().isSetBoundingBoxData());
+                    assertTrue("The 'data' 'literalData' property of OutputDataType should be set",
+                            outputDataType.getData().isSetLiteralData());
+                    assertFalse("The 'data' 'complexData' property of OutputDataType should not be set",
+                            outputDataType.getData().isSetComplexData());
+
+                    assertTrue("The 'data' 'complexData' 'value' property of OutputDataType should be set",
+                            outputDataType.getData().getLiteralData().isSetValue());
+                    assertEquals("The 'data' 'complexData' 'value' property of OutputDataType should be set to 'value1'",
+                            "value1", outputDataType.getData().getLiteralData().getValue());
+
+                    assertTrue("The 'data' 'complexData' 'dataType' property of OutputDataType should be set",
+                            outputDataType.getData().getLiteralData().isSetDataType());
+                    assertEquals("The 'data' 'complexData' 'dataType' property of OutputDataType should be set to 'String'",
+                            "string", outputDataType.getData().getLiteralData().getDataType().toLowerCase());
+                    break;
+                case "Geometry" :
+                case "JDBCColumn" :
+                case "JDBCValue" :
+                case "RawData" :
+                case "Password" :
+                    assertFalse("The 'data' 'boundingBoxData' property of OutputDataType should not be set",
+                            outputDataType.getData().isSetBoundingBoxData());
+                    assertTrue("The 'data' 'literalData' property of OutputDataType should be set",
+                            outputDataType.getData().isSetLiteralData());
+                    assertFalse("The 'data' 'complexData' property of OutputDataType should not be set",
+                            outputDataType.getData().isSetComplexData());
+
+                    assertTrue("The 'data' 'complexData' 'value' property of OutputDataType should be set",
+                            outputDataType.getData().getLiteralData().isSetValue());
+                    assertEquals("The 'data' 'complexData' 'value' property of OutputDataType should be set to '"+type.toLowerCase()+"'",
+                            type.toLowerCase(), outputDataType.getData().getLiteralData().getValue());
+
+                    assertTrue("The 'data' 'complexData' 'dataType' property of OutputDataType should be set",
+                            outputDataType.getData().getLiteralData().isSetDataType());
+                    assertEquals("The 'data' 'complexData' 'dataType' property of OutputDataType should be set to 'String'",
+                            "string", outputDataType.getData().getLiteralData().getDataType().toLowerCase());
+                    break;
+                case "LiteralDataDouble" :
+                    assertFalse("The 'data' 'boundingBoxData' property of OutputDataType should not be set",
+                            outputDataType.getData().isSetBoundingBoxData());
+                    assertTrue("The 'data' 'literalData' property of OutputDataType should be set",
+                            outputDataType.getData().isSetLiteralData());
+                    assertFalse("The 'data' 'complexData' property of OutputDataType should not be set",
+                            outputDataType.getData().isSetComplexData());
+
+                    assertTrue("The 'data' 'literalData' 'dataType' property of OutputDataType should be set",
+                            outputDataType.getData().getLiteralData().isSetDataType());
+                    assertEquals("The 'data' 'literalData' 'dataType' property of OutputDataType should be set to 'Double'",
+                            "double", outputDataType.getData().getLiteralData().getDataType());
+
+                    assertTrue("The 'data' 'literalData' 'value' property of OutputDataType should be set",
+                            outputDataType.getData().getLiteralData().isSetValue());
+                    assertEquals("The 'data' 'literalData' 'value' property of OutputDataType should be set to '10.0'",
+                            "10.0", outputDataType.getData().getLiteralData().getValue());
+                    break;
+                case "LiteralDataString" :
+                    assertFalse("The 'data' 'boundingBoxData' property of OutputDataType should not be set",
+                            outputDataType.getData().isSetBoundingBoxData());
+                    assertTrue("The 'data' 'literalData' property of OutputDataType should be set",
+                            outputDataType.getData().isSetLiteralData());
+                    assertFalse("The 'data' 'complexData' property of OutputDataType should not be set",
+                            outputDataType.getData().isSetComplexData());
+
+                    assertTrue("The 'data' 'literalData' 'value' property of OutputDataType should be set",
+                            outputDataType.getData().getLiteralData().isSetValue());
+                    assertEquals("The 'data' 'literalData' 'value' property of OutputDataType should be set to '"+type+"'",
+                            type, outputDataType.getData().getLiteralData().getValue());
+                    break;
+                case "BoundingBoxData" :
+                    assertTrue("The 'data' 'boundingBoxData' property of OutputDataType should be set",
+                            outputDataType.getData().isSetBoundingBoxData());
+                    assertFalse("The 'data' 'literalData' property of OutputDataType should not be set",
+                            outputDataType.getData().isSetLiteralData());
+                    assertFalse("The 'data' 'complexData' property of OutputDataType should not be set",
+                            outputDataType.getData().isSetComplexData());
+
+                    assertTrue("The 'data' 'boundingBoxData' 'upperCorner' property of OutputDataType should be set",
+                            outputDataType.getData().getBoundingBoxData().isSetUpperCorner());
+                    assertArrayEquals("The 'data' 'boundingBoxData' 'upperCorner' property of OutputDataType should be set to '[1.0, 1.1]'",
+                            new Double[]{1.0, 1.1}, outputDataType.getData().getBoundingBoxData().getUpperCorner().toArray());
+
+                    assertTrue("The 'data' 'boundingBoxData' 'lowerCorner' property of OutputDataType should be set",
+                            outputDataType.getData().getBoundingBoxData().isSetLowerCorner());
+                    assertArrayEquals("The 'data' 'boundingBoxData' 'lowerCorner' property of OutputDataType should be set to '[0.0, 0.1]'",
+                            new Double[]{0.0, 0.1}, outputDataType.getData().getBoundingBoxData().getLowerCorner().toArray());
+
+                    assertTrue("The 'data' 'boundingBoxData' 'crs' property of OutputDataType should be set",
+                            outputDataType.getData().getBoundingBoxData().isSetCrs());
+                    assertEquals("The 'data' 'boundingBoxData' 'crs' property of OutputDataType should be set to 'EPSG:4326'",
+                            "EPSG:4326", outputDataType.getData().getBoundingBoxData().getCrs());
+
+                    assertTrue("The 'data' 'boundingBoxData' 'dimensions' property of OutputDataType should be set",
+                            outputDataType.getData().getBoundingBoxData().isSetDimensions());
+                    assertEquals("The 'data' 'boundingBoxData' 'dimensions' property of OutputDataType should be set to '2'",
+                            new BigInteger("2"), outputDataType.getData().getBoundingBoxData().getDimensions());
+                    break;
+                default :
+                    fail("Invalid output '"+type+"'");
+                    break;
+            }
+        }
+
     }
 
     /**

--- a/service/src/test/resources/org/orbisgis/orbiswps/service/operations/fullScript.groovy
+++ b/service/src/test/resources/org/orbisgis/orbiswps/service/operations/fullScript.groovy
@@ -39,6 +39,7 @@
  */
 package org.orbisgis.orbiswps.service
 
+import com.vividsolutions.jts.geom.Geometry
 import org.orbisgis.orbiswps.groovyapi.input.BoundingBoxInput
 import org.orbisgis.orbiswps.groovyapi.input.EnumerationInput
 import org.orbisgis.orbiswps.groovyapi.input.GeometryInput
@@ -144,7 +145,7 @@ String inputJDBCTable
         identifier = "input:jdbccolumn",
         metadata = ["website","metadata"]
 )
-String inputJDBCColumn
+String[] inputJDBCColumn
 
 @JDBCValueInput(
         title = "Input JDBCValue",
@@ -156,7 +157,7 @@ String inputJDBCColumn
         identifier = "input:jdbcvalue",
         metadata = ["website","metadata"]
 )
-String inputJDBCValue
+String[] inputJDBCValue
 
 @RawDataInput(
         title = "Input RawData",
@@ -168,7 +169,7 @@ String inputJDBCValue
         identifier = "input:rawdata",
         metadata = ["website","metadata"]
 )
-String inputRawData
+String[] inputRawData
 
 @PasswordInput(
         title = "Input Password",
@@ -217,7 +218,7 @@ String inputLiteralString = "dflt"
         dimension = 2,
         metadata = ["website","metadata"]
 )
-String inputBoundingBox
+Geometry inputBoundingBox
 
 /*****************/
 /** OUTPUT Data **/
@@ -266,7 +267,7 @@ String outputJDBCTable
         identifier = "output:jdbccolumn",
         metadata = ["website","metadata"]
 )
-String outputJDBCColumn
+String[] outputJDBCColumn
 
 @JDBCValueOutput(
         title = "Output JDBCValue",
@@ -276,7 +277,7 @@ String outputJDBCColumn
         identifier = "output:jdbcvalue",
         metadata = ["website","metadata"]
 )
-String outputJDBCValue
+String[] outputJDBCValue
 
 @RawDataOutput(
         title = "Output RawData",
@@ -286,7 +287,7 @@ String outputJDBCValue
         identifier = "output:rawdata",
         metadata = ["website","metadata"]
 )
-String outputRawData
+String[] outputRawData
 
 @PasswordOutput(
         title = "Output Password",
@@ -327,5 +328,5 @@ String outputLiteralString = "dflt"
         dimension = 2,
         metadata = ["website","metadata"]
 )
-String outputBoundingBox
+Geometry outputBoundingBox
 


### PR DESCRIPTION
 Adds an execution test in order to check if all the data types are well recognized by the execution.
Convert all the WPS 1.0.0 complex output except JDBCTable into literal one.